### PR TITLE
Add overlay component for job role selection

### DIFF
--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -1,13 +1,10 @@
 import { useState, useEffect } from 'react';
-import { ResumeRole } from '@/hooks/useResumeRole';
 
 interface NavigationProps {
-  currentRole: ResumeRole;
-  onRoleChange: (role: ResumeRole) => void;
   onDownloadPDF: () => void;
 }
 
-export default function Navigation({ currentRole, onRoleChange, onDownloadPDF }: NavigationProps) {
+export default function Navigation({ onDownloadPDF }: NavigationProps) {
   const [isScrolled, setIsScrolled] = useState(false);
 
   useEffect(() => {
@@ -19,36 +16,12 @@ export default function Navigation({ currentRole, onRoleChange, onDownloadPDF }:
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const roles: Array<{ key: ResumeRole; label: string }> = [
-    { key: 'general', label: 'General Manager' },
-    { key: 'frontend', label: 'Frontend Developer' },
-    { key: 'it', label: 'IT Manager' },
-    { key: 'pm', label: 'Project Manager' }
-  ];
 
   return (
     <nav className={`sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-subtle shadow-sm no-print transition-all duration-300 ${isScrolled ? 'py-1' : 'py-2'}`}>
       <div className={`max-w-6xl mx-auto px-6 transition-all duration-300 ${isScrolled ? 'scale-91' : 'scale-95'}`}>
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
           <div className={`font-semibold text-navy transition-all duration-300 ${isScrolled ? 'text-sm' : 'text-md'}`}>Sean Berg Resume</div>
-          
-          <div className="flex flex-wrap justify-center gap-1">
-            {roles.map(({ key, label }) => (
-              <button
-                key={key}
-                onClick={() => onRoleChange(key)}
-                className={`rounded-lg font-medium transition-all duration-300 ${
-                  isScrolled ? 'px-2 py-1 text-sm' : 'px-3 py-1'
-                } ${
-                  currentRole === key
-                    ? 'bg-navy text-white shadow-lg'
-                    : 'bg-subtle text-gray-700 hover:bg-trust-blue hover:text-white'
-                }`}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
           
           <button
             onClick={onDownloadPDF}

--- a/client/src/components/Overlay.tsx
+++ b/client/src/components/Overlay.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { ResumeRole } from "@/hooks/useResumeRole";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface OverlayProps {
+  currentRole: ResumeRole;
+  onRoleChange: (role: ResumeRole) => void;
+}
+
+export default function Overlay({ currentRole, onRoleChange }: OverlayProps) {
+  const [open, setOpen] = useState(true);
+
+  const roles: Array<{ key: ResumeRole; label: string }> = [
+    { key: "general", label: "General Manager" },
+    { key: "frontend", label: "Frontend Developer" },
+    { key: "it", label: "IT Manager" },
+    { key: "pm", label: "Project Manager" },
+  ];
+
+  return (
+    <div className="no-print fixed top-16 right-0 z-40 flex">
+      <button
+        onClick={() => setOpen(!open)}
+        className="relative -left-7 top-4 flex h-6 w-6 items-center justify-center rounded-full border bg-white shadow"
+      >
+        {open ? (
+          <ChevronRight className="h-4 w-4" />
+        ) : (
+          <ChevronLeft className="h-4 w-4" />
+        )}
+      </button>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="right" className="w-60 p-4 pt-10 [&>button]:hidden">
+          <div className="flex flex-col gap-2">
+            {roles.map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => onRoleChange(key)}
+                className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  currentRole === key
+                    ? "bg-navy text-white shadow"
+                    : "bg-subtle text-gray-700 hover:bg-trust-blue hover:text-white"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/client/src/pages/resume.tsx
+++ b/client/src/pages/resume.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useResumeRole } from '@/hooks/useResumeRole';
 import { usePDFGenerator } from '@/components/PDFGenerator';
 import Navigation from '@/components/Navigation';
+import Overlay from '@/components/Overlay';
 import Header from '@/components/Header';
 import Highlights from '@/components/Highlights';
 import Competencies from '@/components/Competencies';
@@ -33,11 +34,8 @@ export default function Resume() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-bg-main to-white">
-      <Navigation 
-        currentRole={currentRole}
-        onRoleChange={switchRole}
-        onDownloadPDF={handleDownloadPDF}
-      />
+      <Navigation onDownloadPDF={handleDownloadPDF} />
+      <Overlay currentRole={currentRole} onRoleChange={switchRole} />
       
       <main className="max-w-4xl mx-auto px-4 py-1">
         <Header 


### PR DESCRIPTION
## Summary
- move job role buttons to new Overlay component
- strip role buttons from Navigation
- use Overlay on resume page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_684dd71deb44832b87233d4ea0b19094