### PR TITLE
Fix overlay role button layout

### DIFF
--- a/client/src/components/Overlay.tsx
+++ b/client/src/components/Overlay.tsx
@@ -19,41 +19,43 @@ export default function Overlay({ currentRole, onRoleChange }: OverlayProps) {
 
   return (
     <div className="no-print fixed top-16 right-0 z-40 flex items-start">
-      <div
-        className={`flex w-2/3 transform items-center gap-2 rounded-l-lg border bg-white/95 px-3 py-2 shadow transition-transform ${
-          open ? "translate-x-0" : "translate-x-full"
-        }`}
-      >
-        <button
-          onClick={() => setOpen(false)}
-          className="mr-2 flex h-6 w-6 items-center justify-center rounded-full border bg-white shadow"
+      <div className="relative">
+        <div
+          className={`absolute right-0 flex w-fit transform items-center gap-2 rounded-l-lg border bg-white/95 px-3 py-2 shadow transition-transform ${
+            open ? "translate-x-0" : "translate-x-full"
+          }`}
         >
-          <ChevronRight className="h-4 w-4" />
-        </button>
-        <div className="flex flex-wrap gap-2">
-          {roles.map(({ key, label }) => (
-            <button
-              key={key}
-              onClick={() => onRoleChange(key)}
-              className={`rounded-lg px-3 py-1 text-sm font-medium transition-colors ${
-                currentRole === key
-                  ? "bg-navy text-white shadow"
-                  : "bg-subtle text-gray-700 hover:bg-trust-blue hover:text-white"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
+          <button
+            onClick={() => setOpen(false)}
+            className="mr-2 flex h-6 w-6 items-center justify-center rounded-full border bg-white shadow"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+          <div className="flex gap-2 whitespace-nowrap">
+            {roles.map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => onRoleChange(key)}
+                className={`rounded-lg px-3 py-1 text-sm font-medium transition-colors ${
+                  currentRole === key
+                    ? "bg-navy text-white shadow"
+                    : "bg-subtle text-gray-700 hover:bg-trust-blue hover:text-white"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
+        {!open && (
+          <button
+            onClick={() => setOpen(true)}
+            className="flex h-6 w-6 items-center justify-center rounded-full border bg-white shadow"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+        )}
       </div>
-      {!open && (
-        <button
-          onClick={() => setOpen(true)}
-          className="ml-1 flex h-6 w-6 items-center justify-center rounded-full border bg-white shadow"
-        >
-          <ChevronLeft className="h-4 w-4" />
-        </button>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show resume role buttons in a single row
- keep chevron handle visible when collapsed so the panel can be reopened

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684e142e295c832b9e802c27c0c089f9